### PR TITLE
CI/CD for ergohaven firmware

### DIFF
--- a/.github/workflows/build-ergohaven.yml
+++ b/.github/workflows/build-ergohaven.yml
@@ -1,0 +1,45 @@
+name: Build Ergohaven
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+
+  build-ergohaven:
+    name: Build Ergohaven keymaps
+    runs-on: ubuntu-latest
+    container: ghcr.io/qmk/qmk_cli
+
+    steps:
+    - name: (actions) Checkout Vial repo
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+        submodules: recursive
+
+    - name: Build
+      id: build
+      run: |
+        git config --global --add safe.directory $(pwd)
+        qmk compile -kb ergohaven/k03 -km no-enc
+        qmk compile -kb ergohaven/k03 -km enc-left
+        qmk compile -kb ergohaven/k03 -km enc-right
+        qmk compile -kb ergohaven/k03 -km enc-left-right
+        qmk compile -kb ergohaven/velvet/rev1 -km v1
+        qmk compile -kb ergohaven/velvet -km v2
+        qmk compile -kb ergohaven/hpd -km v1
+        qmk compile -kb ergohaven/k02 -km v1
+        qmk compile -kb ergohaven/remnant -km v1
+        qmk compile -kb ergohaven/planeta/rev1 -km v1
+        qmk compile -kb ergohaven/planeta -km v2
+        qmk compile -kb ergohaven/planeta -km hid
+        # qmk compile -kb ergohaven/macropad -km v1
+
+    - uses: actions/upload-artifact@v4
+      name: Upload
+      id: upload
+      with:
+        path: .build/*.uf2
+        name: ergohaven_fw

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,36 @@
+name: Pre-Release
+
+on:
+  push:
+    branches: ['vial']
+
+jobs:
+
+  build-ergohaven:
+    uses: ./.github/workflows/build-ergohaven.yml
+
+  pre-release:
+    name: Pre-Release
+    needs:
+      - build-ergohaven
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'write'
+      packages: 'write'
+      pull-requests: 'read'
+
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v4
+        with:
+          path: ergohaven_fw
+
+      - name: Create Release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: '${{ secrets.GITHUB_TOKEN }}'
+          automatic_release_tag: 'latest'
+          prerelease: true
+          title: 'Latest Build'
+          files: |
+            ergohaven_fw/**/*.uf2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+
+  build-ergohaven:
+    uses: ./.github/workflows/build-ergohaven.yml
+
+  pre-release:
+    name: Pre-Release
+    needs:
+      - build-ergohaven
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'write'
+      packages: 'write'
+      pull-requests: 'read'
+
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v4
+        with:
+          path: ergohaven_fw
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: rename
+          version: 1.0
+
+      - name: Rename
+        run: |
+          cd ergohaven_fw/ergohaven_fw
+          rename 's/(rev1_|rev2_)//; s/ergohaven_/'${GITHUB_REF_NAME}'_'/ *.uf2
+
+      - name: Create Release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: '${{ secrets.GITHUB_TOKEN }}'
+          prerelease: false
+          files: |
+            ergohaven_fw/**/*.uf2


### PR DESCRIPTION
This commit add capability for auto building ergohaven firmware.

- `build-ergohaven.yml` creates artifact with ergohaven keymaps, triggers each pull request and can be reused for other workflows
- `pre-release.yml` creates release with tag latest, triggers on commit in branch `vial`
- `release.yml` triggers on pushing new tag, creates release with that tag

Note:
- Release tag should match with [Semantic Versioning](https://semver.org) scheme (three numbers like MAJOR.MINOR.PATCH) 
- Building macropad firmware is commented because its sources were accidentally removed