### PR TITLE
toggle language with M30 and M31

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,9 @@ jobs:
         with:
           path: ergohaven_fw
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: rename
-          version: 1.0
+      - name: Configure
+        run: |
+          sudo apt-get install rename
 
       - name: Rename
         run: |

--- a/keyboards/ergohaven/hpd/keymaps/v1/vial.json
+++ b/keyboards/ergohaven/hpd/keymaps/v1/vial.json
@@ -57,13 +57,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/k02/keymaps/v1/vial.json
+++ b/keyboards/ergohaven/k02/keymaps/v1/vial.json
@@ -57,13 +57,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/k03/keymaps/enc-left-right/vial.json
+++ b/keyboards/ergohaven/k03/keymaps/enc-left-right/vial.json
@@ -58,13 +58,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/k03/keymaps/enc-left/vial.json
+++ b/keyboards/ergohaven/k03/keymaps/enc-left/vial.json
@@ -58,13 +58,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/k03/keymaps/enc-right/vial.json
+++ b/keyboards/ergohaven/k03/keymaps/enc-right/vial.json
@@ -58,13 +58,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",
@@ -182,13 +182,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/k03/keymaps/no-enc/vial.json
+++ b/keyboards/ergohaven/k03/keymaps/no-enc/vial.json
@@ -58,13 +58,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_M20",
+        "title": "Set toggle languge to M20",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/planeta/keymaps/hid/vial.json
+++ b/keyboards/ergohaven/planeta/keymaps/hid/vial.json
@@ -53,13 +53,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/planeta/keymaps/v1/vial.json
+++ b/keyboards/ergohaven/planeta/keymaps/v1/vial.json
@@ -53,13 +53,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/planeta/keymaps/v2/vial.json
+++ b/keyboards/ergohaven/planeta/keymaps/v2/vial.json
@@ -53,13 +53,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/remnant/keymaps/v1/vial.json
+++ b/keyboards/ergohaven/remnant/keymaps/v1/vial.json
@@ -58,13 +58,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/velvet/keymaps/v1/vial.json
+++ b/keyboards/ergohaven/velvet/keymaps/v1/vial.json
@@ -53,13 +53,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/keyboards/ergohaven/velvet/keymaps/v2/vial.json
+++ b/keyboards/ergohaven/velvet/keymaps/v2/vial.json
@@ -52,13 +52,13 @@
         "shortName": "RuEn\nRu"
         },
 
-        {"name": "LG_SET_GUI_SPC",
-        "title": "Set toggle languge to Win+Space",
-        "shortName": "RuEn\nWinSpc"
+        {"name": "LG_SET_M30",
+        "title": "Set toggle languge to Macro 30",
+        "shortName": "RuEn\nM30"
         },
-        {"name": "LG_SET_SFT_CTL",
-        "title": "Set toggle languge to Shift+Control",
-        "shortName": "RuEn\nSftCtl"
+        {"name": "LG_SET_M31",
+        "title": "Set toggle languge to Macro 31",
+        "shortName": "RuEn\nM31"
         },
         {"name": "LG_SET_SFT_ALT",
         "title": "Set toggle languge to Shift+Alt",

--- a/users/ergohaven/lang_ru_en.c
+++ b/users/ergohaven/lang_ru_en.c
@@ -5,20 +5,25 @@ static uint8_t cur_lang = LANG_EN;
 static uint8_t tg_mode = TG_SFT_ALT;
 
 void set_lang(uint8_t lang) {
-    if (cur_lang != lang) {
-        if (tg_mode == TG_GUI_SPC) {
-            add_oneshot_mods(MOD_BIT_LGUI);
-            tap_code(KC_SPC);
-        } else if (tg_mode == TG_SFT_CTL) {
-            register_mods(MOD_BIT_LSHIFT | MOD_BIT_LCTRL);
-            unregister_mods(MOD_BIT_LSHIFT | MOD_BIT_LCTRL);
-        } else if (tg_mode == TG_SFT_ALT) {
-            register_mods(MOD_BIT_LSHIFT | MOD_BIT_LALT);
-            unregister_mods(MOD_BIT_LSHIFT | MOD_BIT_LALT);
-        }
+    if (cur_lang == lang) return;
 
-        cur_lang = lang;
+    switch (tg_mode) {
+        case TG_MACRO30:
+            dynamic_keymap_macro_send(QK_MACRO_30 - QK_MACRO);
+            break;
+        case TG_MACRO31:
+            dynamic_keymap_macro_send(QK_MACRO_31 - QK_MACRO);
+            break;
+        case TG_SFT_ALT:
+            register_code(KC_LALT);
+            register_code(KC_LSFT);
+            unregister_code(KC_LSFT);
+            unregister_code(KC_LALT);
+        default:
+            break;
     }
+
+    cur_lang = lang;
 }
 
 void lang_toggle(void) {
@@ -97,12 +102,12 @@ bool process_record_lang(uint16_t keycode, keyrecord_t* record) {
             if (record->event.pressed) set_lang(LANG_RU);
             return false;
 
-        case LG_SET_GUI_SPC:
-            tg_mode = TG_GUI_SPC;
+        case LG_SET_M30:
+            tg_mode = TG_MACRO30;
             return false;
 
-        case LG_SET_SFT_CTL:
-            tg_mode = TG_SFT_CTL;
+        case LG_SET_M31:
+            tg_mode = TG_MACRO31;
             return false;
 
         case LG_SET_SFT_ALT:

--- a/users/ergohaven/lang_ru_en.h
+++ b/users/ergohaven/lang_ru_en.h
@@ -6,8 +6,8 @@ enum lang_ru_en_custom_keycodes {
     LG_SYNC,
     LG_SET_EN,
     LG_SET_RU,
-    LG_SET_GUI_SPC,
-    LG_SET_SFT_CTL,
+    LG_SET_M30,
+    LG_SET_M31,
     LG_SET_SFT_ALT,
 
     // symbols exist in russian and english layout
@@ -42,7 +42,7 @@ enum lang_ru_en_custom_keycodes {
 
 enum { LANG_EN = 0, LANG_RU };
 
-enum { TG_GUI_SPC = 0, TG_SFT_CTL, TG_SFT_ALT };
+enum { TG_MACRO30 = 0, TG_MACRO31, TG_SFT_ALT };
 
 bool process_record_lang(uint16_t keycode, keyrecord_t *record);
 


### PR DESCRIPTION
![image](https://github.com/ergohaven/vial-qmk/assets/12847693/544af106-5c7b-41bb-a9bd-4dd7a518598c)

Для переключения раскладки теперь доступны три варианта:
- M30 - использовать для переключения макрос 30
- M31 - использовать для переключения макрос 31 (можно использовать при необходимости назначить разные комбинации переключения раскладки для разных ОС)
- SftAlt - использовать комбинацию клавиш Shift+Alt (вариант по умолчанию)

Благодаря макросам можно гибко настроить переключение для различных ОС, подобрать подходящие тайминги.

Например, если хочется сделать переключение раскладки в Windows не по дефолтному Shift+Alt, а по WIn+Space, нужно создать такой макрос M30 (или M31)
![image](https://github.com/ergohaven/vial-qmk/assets/12847693/7d410bf2-5e51-4502-92ea-a75ce6703527)

После этого необходимо настроить клавиатуру для использования этого макроса. Для этого нужно добавить клавишу RuEn M30 куда-нибудь в слой (например, слой №3 Adjust) а затем нажать ее. Сохранения настроек пока не предусмотрено, поэтому после включения клавиатуры нужно будет один раз нажать эту клавишу, т.к. по умолчанию включается  дефолтное Shift+Alt.

Другой пример (ради чего всё затеивалось) - переключение раскладки для MacOS. У одного из пользователей заработал следующий макрос
<img width="391" alt="image" src="https://github.com/ergohaven/vial-qmk/assets/12847693/d3319627-cc5f-4e49-a4f2-1fdb64a0e5f5">

Возможно, потребуется некоторая настройка задержек в макросах, так  как на разных системах могут потребоваться разные задержки.

