### PR TITLE
Функции для управления языком доступные снаружи.

### DIFF
--- a/keyboards/ergohaven/ergohaven_ruen.c
+++ b/keyboards/ergohaven/ergohaven_ruen.c
@@ -60,7 +60,14 @@ void set_lang(uint8_t lang) {
         default:
             break;
     }
-    cur_lang = lang;
+    set_cur_lang(lang);
+}
+
+void set_cur_lang(uint8_t lang) {
+    if (cur_lang != lang) {
+        cur_lang = lang;
+        on_change_lang_cb(cur_lang);
+    }
 }
 
 void set_ruen_toggle_mode(uint8_t mode) {
@@ -93,17 +100,11 @@ bool get_ruen_mac_layout(void) {
 }
 
 void lang_toggle(void) {
-    if (cur_lang == LANG_EN)
-        set_lang(LANG_RU);
-    else
-        set_lang(LANG_EN);
+    set_lang((cur_lang == LANG_EN) ? LANG_RU : LANG_EN);
 }
 
 void lang_sync(void) {
-    if (cur_lang == LANG_EN)
-        cur_lang = LANG_RU;
-    else
-        cur_lang = LANG_EN;
+    set_cur_lang((cur_lang == LANG_EN) ? LANG_RU : LANG_EN);
 }
 
 uint8_t get_cur_lang(void) {
@@ -351,4 +352,7 @@ void housekeeping_task_ruen(void) {
             cur_lang = LANG_RU;
         hid_data->layout_changed = false;
     }
+}
+
+__attribute__((weak)) void on_change_lang_cb(uint8_t lang) {
 }

--- a/keyboards/ergohaven/ergohaven_ruen.h
+++ b/keyboards/ergohaven/ergohaven_ruen.h
@@ -76,6 +76,10 @@ void housekeeping_task_ruen(void);
 
 uint8_t get_cur_lang(void);
 
+void set_lang(uint8_t lang);
+
+void set_cur_lang(uint8_t lang);
+
 void set_ruen_toggle_mode(uint8_t mode);
 
 uint8_t get_ruen_toggle_mode(void);
@@ -83,3 +87,5 @@ uint8_t get_ruen_toggle_mode(void);
 void set_ruen_mac_layout(bool mac_layout);
 
 bool get_ruen_mac_layout(void);
+
+void on_change_lang_cb(uint8_t lang);


### PR DESCRIPTION
`void set_lang(uint8_t lang)` — сделал доступной снаружи, чтобы можно было в пользовательском пространстве менять язык без костылей. 

`void set_cur_lang(uint8_t lang)` — меняет только внутреннее состояние. 
Нужна чтобы синхронизировать состояния, когда переключили язык штатно — без RU-EN клавиш. 

Если можно это сделать прям из коробки было бы круто. В духе того: читать что там в макросах и отслеживать когда эти комбинации сработали вне макроса. 

Кроме того, `set_cur_lang` зовет колбэк `void on_change_lang_cb(uint8_t lang)`, который можно переопределить в пользовательском коде. Я на него меняю слой.
