### PR TITLE
Phenom: expose Auto layer timeout setting (qsid 324, like K:04)

### DIFF
--- a/keyboards/ergohaven/config.h
+++ b/keyboards/ergohaven/config.h
@@ -38,7 +38,7 @@
 #define KB_SETTINGS_POINTING_SIZE 8
 #define KB_SETTINGS_POINTING_OFFSET (KB_SETTINGS_RUEN_OFFSET + KB_SETTINGS_RUEN_SIZE)
 #if defined(KEYBOARD_ergohaven_phenom_rev1) || defined(KEYBOARD_ergohaven_phenom_mini_rev1) || defined(KEYBOARD_ergohaven_phenom_micro_rev1)
-#    define KB_SETTINGS_POINTING_PROTOS 29
+#    define KB_SETTINGS_POINTING_PROTOS 30
 #else
 #    define KB_SETTINGS_POINTING_PROTOS 27
 #endif
@@ -51,7 +51,7 @@
 #define KB_SETTINGS_LAYER_LABELS_PROTOS DYNAMIC_KEYMAP_LAYER_COUNT
 
 #if defined(KEYBOARD_ergohaven_phenom_rev1) || defined(KEYBOARD_ergohaven_phenom_mini_rev1) || defined(KEYBOARD_ergohaven_phenom_micro_rev1)
-#    define KB_SETTINGS_SPLIT_POINTING_SIZE 31
+#    define KB_SETTINGS_SPLIT_POINTING_SIZE 32
 #else
 #    define KB_SETTINGS_SPLIT_POINTING_SIZE 22
 #endif

--- a/keyboards/ergohaven/src/eh_pointing.c
+++ b/keyboards/ergohaven/src/eh_pointing.c
@@ -17,7 +17,11 @@ static kb_settings_split_pointing_t kb_settings_phenom_devices;
 pointing_mode_t                pointing_mode = POINTING_MODE_NORMAL;
 
 #define PHENOM_AUTO_MOUSE_SUPPORTED_MODES_MASK ((1u << POINTING_MODE_NORMAL) | (1u << POINTING_MODE_SNIPER) | (1u << POINTING_MODE_SCROLL) | (1u << POINTING_MODE_TEXT))
-#define PHENOM_SPLIT_POINTING_SETTINGS_VERSION 5
+#define PHENOM_AUTO_MOUSE_TIMEOUT_STEP_MS 250
+#define PHENOM_AUTO_MOUSE_TIMEOUT_IDX_COUNT 6
+// 750 ms, the closest step to QMK's stock AUTO_MOUSE_TIME (650 ms).
+#define PHENOM_AUTO_MOUSE_TIMEOUT_DEFAULT_IDX 2
+#define PHENOM_SPLIT_POINTING_SETTINGS_VERSION 6
 
 static uint8_t phenom_auto_mouse_mode_mask(pointing_mode_t mode) {
     if (mode < POINTING_MODE_NORMAL || mode > POINTING_MODE_USR3) {
@@ -41,6 +45,9 @@ static void apply_auto_mouse_settings(void) {
     auto_mouse_layer_off();
     set_auto_mouse_enable(enable);
     set_auto_mouse_layer(get_split_pointing_auto_mouse_layer());
+#    ifdef EH_KEYBOARD_SPLIT_POINTING_V2
+    set_auto_mouse_timeout((uint16_t)(get_split_pointing_auto_mouse_timeout_idx() + 1) * PHENOM_AUTO_MOUSE_TIMEOUT_STEP_MS);
+#    endif
 #    ifdef RGBLIGHT_ENABLE
     layer_state_set_rgb(layer_state | default_layer_state);
 #    endif
@@ -85,6 +92,7 @@ kb_settings_split_pointing_t get_split_pointing_settings_default(void) {
         .side_auto_mouse_layer  = {AUTO_MOUSE_DEFAULT_LAYER, AUTO_MOUSE_DEFAULT_LAYER},
         .invert_text            = {false, false},
         .version                = PHENOM_SPLIT_POINTING_SETTINGS_VERSION,
+        .auto_mouse_timeout_idx = PHENOM_AUTO_MOUSE_TIMEOUT_DEFAULT_IDX,
 #endif
     };
     return dflt;
@@ -126,7 +134,8 @@ static kb_settings_split_pointing_t kb_settings_split_pointing_sanitize(kb_setti
             config.side_auto_mouse_layer[side]  = legacy_auto_mouse_layer;
             config.invert_text[side]            = false;
         }
-        config.version = PHENOM_SPLIT_POINTING_SETTINGS_VERSION;
+        config.auto_mouse_timeout_idx = PHENOM_AUTO_MOUSE_TIMEOUT_DEFAULT_IDX;
+        config.version                = PHENOM_SPLIT_POINTING_SETTINGS_VERSION;
     }
 #endif
     for (uint8_t side = 0; side < SPLIT_POINTING_SIDE_COUNT; ++side) {
@@ -153,6 +162,9 @@ static kb_settings_split_pointing_t kb_settings_split_pointing_sanitize(kb_setti
         config.auto_mouse_layer = AUTO_MOUSE_DEFAULT_LAYER;
     }
 #ifdef EH_KEYBOARD_SPLIT_POINTING_V2
+    if (config.auto_mouse_timeout_idx >= PHENOM_AUTO_MOUSE_TIMEOUT_IDX_COUNT) {
+        config.auto_mouse_timeout_idx = PHENOM_AUTO_MOUSE_TIMEOUT_DEFAULT_IDX;
+    }
     config.version = PHENOM_SPLIT_POINTING_SETTINGS_VERSION;
 #endif
     return config;
@@ -406,6 +418,30 @@ void set_split_pointing_auto_mouse_layer(uint8_t layer) {
     }
     new_config.auto_mouse_layer = layer;
     kb_settings_split_pointing_update(new_config);
+}
+
+uint8_t get_split_pointing_auto_mouse_timeout_idx(void) {
+#ifdef EH_KEYBOARD_SPLIT_POINTING_V2
+    if (kb_settings_phenom_devices.auto_mouse_timeout_idx >= PHENOM_AUTO_MOUSE_TIMEOUT_IDX_COUNT) {
+        return PHENOM_AUTO_MOUSE_TIMEOUT_DEFAULT_IDX;
+    }
+    return kb_settings_phenom_devices.auto_mouse_timeout_idx;
+#else
+    return PHENOM_AUTO_MOUSE_TIMEOUT_DEFAULT_IDX;
+#endif
+}
+
+void set_split_pointing_auto_mouse_timeout_idx(uint8_t idx) {
+#ifdef EH_KEYBOARD_SPLIT_POINTING_V2
+    kb_settings_split_pointing_t new_config = kb_settings_phenom_devices;
+    if (idx >= PHENOM_AUTO_MOUSE_TIMEOUT_IDX_COUNT) {
+        idx = PHENOM_AUTO_MOUSE_TIMEOUT_DEFAULT_IDX;
+    }
+    new_config.auto_mouse_timeout_idx = idx;
+    kb_settings_split_pointing_update(new_config);
+#else
+    (void)idx;
+#endif
 }
 
 bool get_split_pointing_side_invert_text(split_pointing_side_t side) {

--- a/keyboards/ergohaven/src/eh_pointing.h
+++ b/keyboards/ergohaven/src/eh_pointing.h
@@ -58,6 +58,8 @@ typedef struct {
     uint8_t side_auto_mouse_layer[SPLIT_POINTING_SIDE_COUNT];
     uint8_t invert_text[SPLIT_POINTING_SIDE_COUNT];
     uint8_t version;
+    // phenom-side-modules-v0.0.3: auto mouse layer timeout, 250 ms * (idx + 1).
+    uint8_t auto_mouse_timeout_idx;
 #endif
 } kb_settings_split_pointing_t;
 
@@ -109,6 +111,8 @@ bool    get_split_pointing_auto_mouse_enable(void);
 void    set_split_pointing_auto_mouse_enable(bool enable);
 uint8_t get_split_pointing_auto_mouse_layer(void);
 void    set_split_pointing_auto_mouse_layer(uint8_t layer);
+uint8_t get_split_pointing_auto_mouse_timeout_idx(void);
+void    set_split_pointing_auto_mouse_timeout_idx(uint8_t idx);
 void    set_pointing_auto_mouse_override(bool enabled, bool active);
 
 void          set_orientation(orientation_t orientation);

--- a/keyboards/ergohaven/src/eh_settings.c
+++ b/keyboards/ergohaven/src/eh_settings.c
@@ -528,6 +528,9 @@ static int modules_select_get(const qmk_settings_proto_t *proto, void *setting, 
         case 143:
             v = get_split_pointing_auto_mouse_layer();
             break;
+        case 324:
+            v = get_split_pointing_auto_mouse_timeout_idx();
+            break;
         default: return -1;
     }
 #else
@@ -569,6 +572,9 @@ static int modules_select_set(const qmk_settings_proto_t *proto, const void *set
             break;
         case 143:
             set_split_pointing_auto_mouse_layer(v);
+            break;
+        case 324:
+            set_split_pointing_auto_mouse_timeout_idx(v);
             break;
         default: return -1;
     }
@@ -1003,5 +1009,10 @@ qmk_settings_proto_t kb_protos[KB_SETTINGS_NPROTOS] PROGMEM = {
     DECLARE_SETTING(317, leds_timeout_get, leds_timeout_set),
     DECLARE_SETTING(318, lcd_brightness_get, lcd_brightness_set),
     DECLARE_SETTING(319, lcd_timeout_get, lcd_timeout_set),
+#if defined(EH_KEYBOARD_SPLIT_POINTING_V2)
+    // Keep qsids in ascending order: qmk_settings_query returns them in table
+    // order and clients advance their cursor to the max qsid of each batch.
+    DECLARE_SETTING(324, modules_select_get, modules_select_set),
+#endif
     // clang-format on
 };

--- a/keyboards/ergohaven/src/json/settings_phenom_modules.json
+++ b/keyboards/ergohaven/src/json/settings_phenom_modules.json
@@ -39,6 +39,7 @@
         { "type": "boolean", "title": "Auto layer in Normal", "qsid": 142, "bit": 0 },
         { "type": "boolean", "title": "Auto layer in Sniper", "qsid": 144, "bit": 0 },
         { "type": "boolean", "title": "Auto layer in Scroll", "qsid": 145, "bit": 0 },
-        { "type": "boolean", "title": "Auto layer in Text", "qsid": 146, "bit": 0 }
+        { "type": "boolean", "title": "Auto layer in Text", "qsid": 146, "bit": 0 },
+        { "type": "select", "title": "Auto layer timeout", "qsid": 324, "variants": ["250 ms", "500 ms", "750 ms", "1000 ms", "1250 ms", "1500 ms"] }
     ]
 }


### PR DESCRIPTION
### What

Expose the auto mouse layer hold time as a Vial setting for the Phenom family (Phenom / Phenom Mini / Phenom Micro), mirroring the field K:04 already has:

```json
{ "type": "select", "title": "Auto layer timeout", "qsid": 324,
  "variants": ["250 ms", "500 ms", "750 ms", "1000 ms", "1250 ms", "1500 ms"] }
```

Entropy already localizes this field for K:04 ("Cover K04 auto layer timeout setting"), so it appears on the Modules page automatically once the firmware exposes it — no app changes needed.

### Why

The time the mouse layer stays active after trackball movement stops was fixed at QMK's stock `AUTO_MOUSE_TIME` (650 ms). It is too short or too long depending on workflow, and changing it required rebuilding the firmware.

### How

- `settings_phenom_modules.json`: add the "Auto layer timeout" select (qsid 324, same variants as K:04) to the "Auto layer" tab.
- `eh_pointing.{h,c}`: persist `auto_mouse_timeout_idx` in `kb_settings_split_pointing_t` (struct version 5 → 6 with migration defaulting to 750 ms — the closest step to the previous 650 ms), apply via `set_auto_mouse_timeout()` in `apply_auto_mouse_settings()`.
- `eh_settings.c`: handle qsid 324 in `modules_select_get/set`, register the proto.
- `config.h`: `KB_SETTINGS_SPLIT_POINTING_SIZE` 31 → 32, `KB_SETTINGS_POINTING_PROTOS` 29 → 30 (Phenom branch only).

The new code is guarded by `EH_KEYBOARD_SPLIT_POINTING_V2`, so non-Phenom boards with auto mouse (HPD, K:03 PRO) keep their current 650 ms behavior.

Note: the EEPROM datablock grows by one byte, so stored keyboard settings (module settings, layer labels) reset to defaults on first boot after flashing — same consequence as previous split-pointing layout changes. Dynamic keymap is unaffected.

### Testing

- Built `ergohaven/phenom/rev1:v1`, `ergohaven/phenom_mini/rev1:v1`, `ergohaven/phenom_micro/rev1:v1` — OK; baked `vial.json` contains the new field.
- Built `ergohaven/k03pro/rev2:v1` as a non-V2 regression check — OK, its `vial.json` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv27LEsfqZahsATZkyKssb