### PR TITLE
Phenom Micro: fix scroll-mode keys typing product info

### DIFF
--- a/keyboards/ergohaven/ergohaven_main.c
+++ b/keyboards/ergohaven/ergohaven_main.c
@@ -102,6 +102,14 @@ bool pre_process_record_kb(uint16_t keycode, keyrecord_t* record) {
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
+    // Some Vial keymaps need to consume keyboard-range user slots before shared
+    // Ergohaven handlers see them.
+#ifdef EH_PROCESS_RECORD_USER_FIRST
+    if (!process_record_user(keycode, record)) {
+        return false;
+    }
+#endif
+
     // #ifdef WPM_ENABLE
     //   if (record->event.pressed) {
     //       extern uint32_t tap_timer;
@@ -233,12 +241,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
             return false;
         }
     }
-
-// Some Vial keymaps need to consume keyboard-range user slots before shared
-// Ergohaven handlers see them.
-#ifdef EH_PROCESS_RECORD_USER_FIRST
-    if (!process_record_user(keycode, record)) return false;
-#endif
 
     if (!process_record_ruen(keycode, record)) return false;
 


### PR DESCRIPTION
### What

Fix both Phenom Micro scroll-mode keys so they enter scroll mode instead of typing the product-information block.
Addresses https://t.me/c/1464748383/7588/131383

### Why

Phenom Micro defines `HRM_GUI_SCR` on the same keyboard-range user slot as `EH_PRINFO`. The shared `process_record_kb()` switch handled that value first, so the keymap-specific hold-tap handler never received it.

Upstream firmware 4.0.5 already updated the default layout and product-version reporting. This PR now contains only the remaining scroll-mode fix.

### How

For keymaps opting into `EH_PROCESS_RECORD_USER_FIRST`, call `process_record_user()` before shared Ergohaven keycode handling. Consumed keycodes return immediately; unconsumed keycodes continue through the existing shared handlers.

### Testing

- `qmk compile -kb ergohaven/phenom_micro/rev1 -km v1`
- `qmk compile -kb ergohaven/phenom_mini/rev1 -km v1`
- callback-order source assertion
- `git diff --check`

Both firmware builds pass against current firmware 4.0.5 in `ghcr.io/qmk/qmk_cli:latest`. Physical Phenom Micro/Windows 10 hardware was unavailable. Existing duplicate encoder-config warnings remain unchanged.